### PR TITLE
Gouvfr is gone ! ✨ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+/udata-front
+/udata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM udata/system
 
-RUN mkdir -p /srv/udata /srv/udata-gouvfr
+RUN mkdir -p /srv/udata /srv/udata-front
 ADD start.sh /srv/start.sh
 ADD udata.cfg /srv/udata.cfg
 RUN chmod +x /srv/start.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - elasticsearch:elasticsearch
     volumes:
       - ./udata:/srv/udata
-      - ./udata-gouvfr:/srv/udata-gouvfr
+      - ./udata-front:/srv/udata-front
       - udata-fs:/udata/fs
     ports:
       - "7000:7000"

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 pip install -r /srv/udata/requirements/develop.pip
 pip install -e /srv/udata/
-pip install -e /srv/udata-gouvfr -r /srv/udata-gouvfr/requirements/test.pip -r requirements/develop.pip
+pip install -e /srv/udata-front -r /srv/udata-front/requirements/test.pip -r requirements/develop.pip
 udata db migrate
 # udata search index
 # udata generate-fixtures

--- a/udata.cfg
+++ b/udata.cfg
@@ -3,14 +3,15 @@ from udata.settings import Defaults
 DEBUG = False
 
 DEFAULT_LANGUAGE = 'fr'
-PLUGINS = ['gouvfr']
+PLUGINS = ['front']
 THEME = 'gouvfr'
+SERVER_NAME = 'dev.local:7000'
 
 MONGODB_HOST = 'mongodb://mongodb:27017/udata'
 
 ELASTICSEARCH_URL = 'elasticsearch:9200'
 
-CACHE_TYPE = 'redis'
+CACHE_TYPE = 'null'
 CACHE_REDIS_URL = 'redis://redis:6379/1'
 CELERY_BROKER_URL = 'redis://redis:6379'
 CELERY_RESULT_BACKEND = 'redis://redis:6379'


### PR DESCRIPTION
It's now `udata-front` 🎉 

This should work "as is" with the current README.
I had to run this manually `docker exec -it udata-docker-dev-env_udata_1 pip install -e /srv/udata-front` because the front-end didn't register (and neither did Sentry), but it might not be needed anymore. If you get 404 errors on the front-end and the admin parts, then run this.

